### PR TITLE
Overwrite callback_url to ignore query string params

### DIFF
--- a/lib/omniauth/strategies/microsoft_office365.rb
+++ b/lib/omniauth/strategies/microsoft_office365.rb
@@ -39,6 +39,10 @@ module OmniAuth
       end
 
       private
+      
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
 
       def avatar_file
         photo = access_token.get("https://outlook.office.com/api/v2.0/me/photo/$value")


### PR DESCRIPTION
Ignoring query string params did the trick to fix https://github.com/murbanski/omniauth-microsoft-office365/issues/1
