### PR TITLE
Dynamic scoping through devise

### DIFF
--- a/lib/omniauth/strategies/microsoft_office365.rb
+++ b/lib/omniauth/strategies/microsoft_office365.rb
@@ -11,9 +11,7 @@ module OmniAuth
         token_url:     "/common/oauth2/v2.0/token"
       }
 
-      option :authorize_params, {
-        scope: "openid email profile https://outlook.office.com/contacts.read",
-      }
+      option :authorize_options, [:scope]
 
       uid { raw_info["Id"] }
 
@@ -51,6 +49,18 @@ module OmniAuth
 
       def callback_url
         options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
+      def authorize_params
+        super.tap do |params|
+          %w[display scope auth_type].each do |v|
+            if request.params[v]
+              params[v.to_sym] = request.params[v]
+            end
+          end
+
+          params[:scope] ||= DEFAULT_SCOPE
+        end
       end
 
       def avatar_file

--- a/lib/omniauth/strategies/microsoft_office365.rb
+++ b/lib/omniauth/strategies/microsoft_office365.rb
@@ -5,6 +5,8 @@ module OmniAuth
     class MicrosoftOffice365 < OmniAuth::Strategies::OAuth2
       option :name, :microsoft_office365
 
+      DEFAULT_SCOPE="openid email profile https://outlook.office.com/contacts.read"
+
       option :client_options, {
         site:          "https://login.microsoftonline.com",
         authorize_url: "/common/oauth2/v2.0/authorize",
@@ -36,6 +38,18 @@ module OmniAuth
         @raw_info ||= access_token.get("https://outlook.office.com/api/v2.0/me/").parsed
       end
 
+      def authorize_params
+        super.tap do |params|
+          %w[display scope auth_type].each do |v|
+            if request.params[v]
+              params[v.to_sym] = request.params[v]
+            end
+          end
+
+          params[:scope] ||= DEFAULT_SCOPE
+        end
+      end
+
       private
 
       def first_last_from_display_name(display_name)
@@ -49,18 +63,6 @@ module OmniAuth
 
       def callback_url
         options[:redirect_uri] || (full_host + script_name + callback_path)
-      end
-
-      def authorize_params
-        super.tap do |params|
-          %w[display scope auth_type].each do |v|
-            if request.params[v]
-              params[v.to_sym] = request.params[v]
-            end
-          end
-
-          params[:scope] ||= DEFAULT_SCOPE
-        end
       end
 
       def avatar_file

--- a/spec/omniauth/strategies/microsoft_office365_spec.rb
+++ b/spec/omniauth/strategies/microsoft_office365_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe OmniAuth::Strategies::MicrosoftOffice365 do
 
     context "when the name is in alternate format" do
       let(:avatar_response) { instance_double(OAuth2::Response, content_type: "image/jpeg", body: "JPEG_STREAM") }
-      
+
       before do
         expect(access_token).to receive(:get).with("https://outlook.office.com/api/v2.0/me/photo/$value")
           .and_return(avatar_response)


### PR DESCRIPTION
Adding authorize_options to allow for passing scope through devise as a parameter
### Example

```
omniauth_devise_auth_path(:microsoft_office365, scope: "openid offline-access ...")
```

applies the scope: openid, offine-access
