### PR TITLE
Allow custom values for state parameter to be sent with the authorize request

### DIFF
--- a/lib/omniauth/strategies/microsoft_office365.rb
+++ b/lib/omniauth/strategies/microsoft_office365.rb
@@ -40,7 +40,7 @@ module OmniAuth
 
       def authorize_params
         super.tap do |params|
-          %w[display scope auth_type].each do |v|
+          %w[display scope auth_type state].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
             end

--- a/spec/omniauth/strategies/microsoft_office365_spec.rb
+++ b/spec/omniauth/strategies/microsoft_office365_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe OmniAuth::Strategies::MicrosoftOffice365 do
                                           cookies: {},
                                           env:     {}) }
         it 'returns the supplied value' do
-          expect(strategy.authorize_params[:state]).to eq('foo')
+          expect(strategy.authorize_params['state']).to eq('foo')
         end
       end
 

--- a/spec/omniauth/strategies/microsoft_office365_spec.rb
+++ b/spec/omniauth/strategies/microsoft_office365_spec.rb
@@ -84,6 +84,24 @@ RSpec.describe OmniAuth::Strategies::MicrosoftOffice365 do
         "state" => /\A\h{48}\z/
       )
     end
+
+    describe 'state params' do
+      context 'when supplied with the request' do
+        let(:request) { double("Request", params:  { 'state' => 'foo' },
+                                          cookies: {},
+                                          env:     {}) }
+        it 'returns the supplied value' do
+          expect(strategy.authorize_params[:state]).to eq('foo')
+        end
+      end
+
+      context 'when not provided' do
+        it 'returns the auto-generated value' do
+          expect(strategy.authorize_params['state']).to match(/\A\h{48}\z/)
+        end
+      end
+    end
+
   end
 
   describe "#info" do


### PR DESCRIPTION
We generate custom strings for the state parameter and noticed that our state values weren't being sent with the authorization request. This pull requests allows those state strings to be included.