### PR TITLE
Add required `name` field. Fix avatar test.

### DIFF
--- a/lib/omniauth/strategies/microsoft_office365.rb
+++ b/lib/omniauth/strategies/microsoft_office365.rb
@@ -20,6 +20,7 @@ module OmniAuth
       info do
         {
           email:           raw_info["mail"] || raw_info["userPrincipalName"],
+          name:            raw_info["displayName"],
           display_name:    raw_info["displayName"],
           first_name:      raw_info["givenName"],
           last_name:       raw_info["surname"],

--- a/spec/omniauth/strategies/microsoft_office365_spec.rb
+++ b/spec/omniauth/strategies/microsoft_office365_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe OmniAuth::Strategies::MicrosoftOffice365 do
 
       it "returns a hash containing normalized user data" do
         expect(strategy.info).to match({
+          name: "Luke Skywalker",
           display_name: "Luke Skywalker",
           email: "luke.skywalker@example.com",
           first_name: "Luke",
@@ -139,7 +140,7 @@ RSpec.describe OmniAuth::Strategies::MicrosoftOffice365 do
     end
 
     context "when user didn't provide avatar image" do
-      let(:avatar_response) { instance_double(OAuth2::Response, "error=" => nil, status: 404, parsed: {}, body: '') }
+      let(:avatar_response) { instance_double(OAuth2::Response, status: 404, parsed: {}, body: '') }
 
       before do
         expect(access_token).to receive(:get).with("https://graph.microsoft.com/v1.0/me/photo/$value")
@@ -148,6 +149,7 @@ RSpec.describe OmniAuth::Strategies::MicrosoftOffice365 do
 
       it "returns a hash containing normalized user data" do
         expect(strategy.info).to match({
+          name: "Luke Skywalker",
           display_name: "Luke Skywalker",
           email: "luke.skywalker@example.com",
           first_name: "Luke",


### PR DESCRIPTION
Add `name` field to omniauth response as described in [Omniauth Hash Schema](https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema).